### PR TITLE
route fixed from sell something - <form> class removed: not needed

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,7 +2,6 @@
   <div class="row justify-content-center align-items-center">
     <div class="col-md-6">
       <div class="col-md-12">
-        <form class="form p-4" method="post">
           <h3 class="text-center">Forgot Your Password?</h3>
           <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
             <%= f.error_notification %>
@@ -18,7 +17,6 @@
               <%= f.button :submit, class:"btn btn-primary btn-md", value: "Send me reset password instructions" %>
             </div>
           <% end %>
-        </form>
       </div>
     </div>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,6 @@
 <div class="container mt-5">
   <div class="row justify-content-center align-items-center">
     <div class="col-md-4">
-        <form class="form p-4" method="post">
         <h3 class="text-center">Log in</h3>
           <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
             <div class="form-inputs">
@@ -20,7 +19,6 @@
             </div>
             </div>
               <% end %>
-        </form>
       </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :products do
-    resources :orders, only: :create
+    resources :orders, only: %i[create]
   end
   resources :users, only: %i[show]
   


### PR DESCRIPTION
this commit removes form class from login and signup pages (simple form is the ultimate form, and removed method: post from these forms)
this solves routes bug and forms's incompatibility
@mbourg  heads-up, also working on these files